### PR TITLE
AS7-6639 synchronize getCache() calls to workaround ISPN-2796

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
@@ -109,9 +109,9 @@ public class DefaultEmbeddedCacheManager extends AbstractDelegatingEmbeddedCache
      * @see org.infinispan.manager.EmbeddedCacheManager#getCache(java.lang.String, boolean)
      */
     @Override
-    public <K, V> Cache<K, V> getCache(String cacheName, boolean start) {
+    public <K, V> Cache<K, V> getCache(String cacheName, boolean createIfAbsent) {
         // Synchronize to workaround ISPN-2796 / AS7-6639
-        if (start) {
+        if (createIfAbsent) {
             return this.getCache(cacheName);
         }
 


### PR DESCRIPTION
With more investigation today and finding the real cause updating the workaround -- until we do an ISPN ugprade.
