### PR TITLE
Apply adhoc properties after formal security configuration, but before everything else.

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteCacheContainerConfigurationServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteCacheContainerConfigurationServiceConfigurator.java
@@ -167,7 +167,11 @@ public class RemoteCacheContainerConfigurationServiceConfigurator extends Capabi
     @Override
     public Configuration get() {
         MBeanServer server = (this.server != null) ? this.server.get() : null;
-        ConfigurationBuilder builder = new ConfigurationBuilder()
+        ConfigurationBuilder builder = new ConfigurationBuilder();
+        // Configure formal security first
+        builder.security().read(this.security.get());
+        // Apply properties next, which may override formal security configuration
+        builder.withProperties(this.properties)
                 .marshaller(new JBossMarshaller(this.loader.get(), this.module.get()))
                 .connectionTimeout(this.connectionTimeout)
                 .keySizeEstimate(this.keySizeEstimate)
@@ -205,10 +209,7 @@ public class RemoteCacheContainerConfigurationServiceConfigurator extends Capabi
             }
         }
 
-        builder.security().read(this.security.get());
         builder.transaction().read(this.transaction.get());
-
-        builder.withProperties(this.properties);
 
         return builder.build();
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/AbstractHotRodWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/AbstractHotRodWebFailoverTestCase.java
@@ -70,11 +70,7 @@ public abstract class AbstractHotRodWebFailoverTestCase extends AbstractWebFailo
         String readResource = String.format("/subsystem=infinispan/remote-cache-container=web/remote-cache=%s:read-resource(include-runtime=true, recursive=true)", this.deploymentName);
         String resetStatistics = String.format("/subsystem=infinispan/remote-cache-container=web/remote-cache=%s:reset-statistics", this.deploymentName);
 
-        ModelNode result;
-
-        // FIXME: checks fail with secured caches.
-        /*
-        result = execute(this.client1, readResource);
+        ModelNode result = execute(this.client1, readResource);
         Assert.assertNotEquals(0L, result.get("hits").asLong());
         Assert.assertNotEquals(0L, result.get("writes").asLong());
 
@@ -85,7 +81,6 @@ public abstract class AbstractHotRodWebFailoverTestCase extends AbstractWebFailo
         result = execute(this.client3, readResource);
         Assert.assertNotEquals(0L, result.get("hits").asLong());
         Assert.assertNotEquals(0L, result.get("writes").asLong());
-        */
 
         execute(this.client1, resetStatistics);
         execute(this.client2, resetStatistics);


### PR DESCRIPTION
Fixes inadvertent disabling of statistics.
