### PR TITLE
[WFLY-20559] Add testsuite dependencies to ensure the build demander modules run before the actual test modules

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -293,16 +293,6 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-x500</artifactId>
         </dependency>
-
-        <!-- Indicate to maven that modules building the feature-pack archives are a dependency -->
-        <!-- Note: Used by wildfly-glow-arquillian-plugin/wildfly-maven-plugin – not an actual class path dependency -->
-        <dependency>
-            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
-            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
-            <version>${testsuite.ee.galleon.pack.version}</version>
-            <scope>test</scope>
-            <type>zip</type>
-        </dependency>
     </dependencies>
 
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -401,6 +401,17 @@
                 <module>aggregator-base</module>
                 <module>integration</module>
             </modules>
+            <dependencies>
+                <!-- Include a dependency on the build demander because in concurrent builds the order
+                     of items in the 'modules' element doesn't ensure earlier modules are
+                     built before later ones. So use a dependency make sure it is executed. -->
+                <dependency>
+                    <groupId>${ee.maven.groupId}</groupId>
+                    <artifactId>wildfly-ts-build-demander-base</artifactId>
+                    <version>${ee.maven.version}</version>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>expansion-server-tests</id>
@@ -411,6 +422,17 @@
                 <module>aggregator-expansion</module>
                 <module>integration</module>
             </modules>
+            <dependencies>
+                <!-- Include a dependency on the build demander because in concurrent builds the order
+                     of items in the 'modules' element doesn't ensure earlier modules are
+                     built before later ones. So use a dependency make sure it is executed. -->
+                <dependency>
+                    <groupId>${full.maven.groupId}</groupId>
+                    <artifactId>wildfly-ts-build-demander-expansion</artifactId>
+                    <version>${full.maven.version}</version>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>preview-server-tests</id>
@@ -420,6 +442,17 @@
                 <module>aggregator-preview</module>
                 <module>integration</module>
             </modules>
+            <dependencies>
+                <!-- Include a dependency on the build demander because in concurrent builds the order
+                     of items in the 'modules' element doesn't ensure earlier modules are
+                     built before later ones. So use a dependency make sure it is executed. -->
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>wildfly-ts-build-demander-preview</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
         </profile>
         <!-- These execute in all feature pack contexts, so declare them here instead
              of repeating this in the aggregator modules -->


### PR DESCRIPTION
Proposed change to https://github.com/wildfly/wildfly/pull/18883